### PR TITLE
Fix black line in user profile popup footer

### DIFF
--- a/css/v3/naat.v3.css
+++ b/css/v3/naat.v3.css
@@ -796,6 +796,7 @@ html {
 
 .footer-3UKYOU {
   background-color: var(--small-user-popout-background-transparency);
+  margin-top: 0;
 }
 
 .threadSidebar-1o3BTy {


### PR DESCRIPTION
There was a black line in the user profile pop up footer caused by `margin-top: -2px;` in the `.footer-3UKYOU` class
![image](https://user-images.githubusercontent.com/45804108/135704711-df96d46d-8d06-4f3b-bd05-f380e2a2aff5.png)